### PR TITLE
RapidOCR等实现 AutoCloseable 接口以预防可能的内存泄漏问题,以更优雅的方式释放资源

### DIFF
--- a/src/main/java/io/github/hzkitty/RapidOCR.java
+++ b/src/main/java/io/github/hzkitty/RapidOCR.java
@@ -16,7 +16,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class RapidOCR {
+public class RapidOCR implements AutoCloseable {
     private final float textScore;          // 过滤阈值
     private final int minHeight;            // 最小高度
     private final float widthHeightRatio;   // 宽高比
@@ -562,6 +562,19 @@ public class RapidOCR {
 
         // 4. 返回修正后的坐标（dtBoxes 已经就地修改）
         return dtBoxes;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (textDet != null) {
+            textDet.close();
+        }
+        if (textCls != null) {
+            textCls.close();
+        }
+        if (textRec != null) {
+            textRec.close();
+        }
     }
 
 }

--- a/src/main/java/io/github/hzkitty/ch_ppocr_cls/TextClassifier.java
+++ b/src/main/java/io/github/hzkitty/ch_ppocr_cls/TextClassifier.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * 对输入图像进行文字方向分类，并在需要时旋转图像。
  */
-public class TextClassifier {
+public class TextClassifier implements AutoCloseable {
 
     // 分类输入图像的形状 [channels, height, width]
     private final int[] clsImageShape;
@@ -272,6 +272,13 @@ public class TextClassifier {
         }
 
         return chwArray;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (inferSession != null) {
+            inferSession.close();
+        }
     }
 
 }

--- a/src/main/java/io/github/hzkitty/ch_ppocr_det/TextDetector.java
+++ b/src/main/java/io/github/hzkitty/ch_ppocr_det/TextDetector.java
@@ -13,7 +13,7 @@ import java.util.*;
 /**
  * 文本检测
  */
-public class TextDetector {
+public class TextDetector implements AutoCloseable {
 
     private final String limitType;        // "min" / "max" 等限制类型
     private final int limitSideLen;        // 限制边长
@@ -211,6 +211,13 @@ public class TextDetector {
         double dx = p2.x - p1.x;
         double dy = p2.y - p1.y;
         return Math.hypot(dx, dy);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (infer != null) {
+            infer.close();
+        }
     }
 
 }

--- a/src/main/java/io/github/hzkitty/ch_ppocr_rec/TextRecognizer.java
+++ b/src/main/java/io/github/hzkitty/ch_ppocr_rec/TextRecognizer.java
@@ -14,7 +14,7 @@ import org.opencv.imgproc.Imgproc;
 import java.util.*;
 import java.util.stream.IntStream;
 
-public class TextRecognizer {
+public class TextRecognizer implements AutoCloseable {
 
     private final OrtInferSession session;
     private final CTCLabelDecode postprocessOp;
@@ -223,6 +223,13 @@ public class TextRecognizer {
         }
 
         return paddingIm;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (session != null) {
+            session.close();
+        }
     }
 
 }

--- a/src/main/java/io/github/hzkitty/utils/OrtInferSession.java
+++ b/src/main/java/io/github/hzkitty/utils/OrtInferSession.java
@@ -16,7 +16,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.List;
 
-public class OrtInferSession {
+public class OrtInferSession implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(OrtInferSession.class);
 
@@ -210,6 +210,16 @@ public class OrtInferSession {
             return buffer.toByteArray();
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws OrtException {
+        if (session != null) {
+            session.close();
+        }
+        if (env != null) {
+            env.close();
         }
     }
 


### PR DESCRIPTION
## Summary

- 将rapidocr4j集成到项目中发现RapidOCR没有通过释放资源的方法,依靠JVM退出来释放资源不太符合工程实践,所以将RapidOCR等实现AutoCloseable 接口,提供手动释放ONNX runtime资源的方法.
- 虽然实际使用RapidOCR单例的,不存在内存泄漏的可能.
- 修复内存泄漏问题：为 `OrtInferSession`、`TextDetector`、`TextClassifier`、`TextRecognizer`、`RapidOCR` 实现 `AutoCloseable` 接口，确保 native 资源（ONNX Runtime）能被正确释放。

## Changes

- `OrtInferSession`: 实现 `AutoCloseable`，`close()` 方法释放 `OrtSession` 和 `OrtEnvironment`
- `TextDetector`: 实现 `AutoCloseable`，委托释放内部 `OrtInferSession`
- `TextClassifier`: 实现 `AutoCloseable`，委托释放内部 `OrtInferSession`
- `TextRecognizer`: 实现 `AutoCloseable`，委托释放内部 `OrtInferSession`
- `RapidOCR`: 实现 `AutoCloseable`，释放所有内部组件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved resource management across all primary OCR processing components with support for automatic cleanup patterns. Developers can now leverage standard Java resource cleanup mechanisms for significantly better resource handling, reducing operational overhead and enabling much more simplified code integration patterns when using the library in their applications and related services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->